### PR TITLE
Ajout extension ".pdf" à l'URL du document gouvernemental

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
   </main>
     <footer>
         Ceci est une version à remplir en ligne du <a
-            href="https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-derogatoire"
+            href="https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestation-de-deplacement-derogatoire.pdf"
             title"Attestation de déplacement dérogatoire">document officiel
         disponible sur le site du ministère de l'intérieur
         </a>


### PR DESCRIPTION
Il manquait l'extension en fin d'URL.